### PR TITLE
Update ForgeRock dependencies to community edition

### DIFF
--- a/openam-tools/pom.xml
+++ b/openam-tools/pom.xml
@@ -80,7 +80,7 @@
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
         <dependency>
-            <groupId>org.forgerock.openam</groupId>
+            <groupId>org.forgerock.ce.openam</groupId>
             <artifactId>openam-clientsdk</artifactId>
             <version>${openam.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<commons-codec.version>1.5</commons-codec.version>
 		<httpclient.version>3.1</httpclient.version>
 		<jasypt.version>1.9.0</jasypt.version>
-		<openam.version>12.0.0</openam.version>
+		<openam.version>11.0.3</openam.version>
 		<amqclient-version>2.7.1</amqclient-version>
 		<cxf.version>3.0.3</cxf.version>
 		<spring.version>4.1.4.RELEASE</spring.version>
@@ -285,22 +285,22 @@
     </dependency>
 			 <!-- OpenAM -->
             <dependency>
-                <groupId>org.forgerock.openam</groupId>
+                <groupId>org.forgerock.ce.openam</groupId>
                 <artifactId>openam-clientsdk</artifactId>
                 <version>${openam.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.openam</groupId>
+                <groupId>org.forgerock.ce.openam</groupId>
                 <artifactId>openam-shared</artifactId>
                 <version>${openam.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.openam</groupId>
+                <groupId>org.forgerock.ce.openam</groupId>
                 <artifactId>openam-federation-library</artifactId>
                 <version>${openam.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.openam</groupId>
+                <groupId>org.forgerock.ce.openam</groupId>
                 <artifactId>openam-idpdiscovery</artifactId>
                 <version>${openam.version}</version>
             </dependency>
@@ -532,7 +532,7 @@
 		<repository>
 			<id>forgerock</id>
 			<name>ForgeRock</name>
-			<url>http://maven.forgerock.org/repo/repo</url>
+			<url>http://maven.forgerock.org/repo/community</url>
 		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
ForgeRock has removed access to compiled artifacts that are not "community edition". This broke the NICS build which was relying on these Maven artifacts. This pull request switches the build to use the latest community edition of OpenAM.